### PR TITLE
Add ability to get content's HTML

### DIFF
--- a/readability.go
+++ b/readability.go
@@ -104,7 +104,7 @@ func (d *Document) initializeHtml(s string) error {
 	return nil
 }
 
-func (d *Document) Content() string {
+func (d *Document) ContentWithHTML() (content string, html string) {
 	if d.content == "" {
 		d.prepareCandidates()
 
@@ -129,14 +129,19 @@ func (d *Document) Content() string {
 			if retry {
 				Logger.Printf("Retrying with length %d < retry length %d\n", length, d.RetryLength)
 				_ = d.initializeHtml(d.input)
-				articleText = d.Content()
+				articleText, _ = d.ContentWithHTML()
 			}
 		}
 
 		d.content = articleText
 	}
 
-	return d.content
+	return d.content, d.getArticle()
+}
+
+func (d *Document) Content() (content string) {
+	content, _ = d.ContentWithHTML()
+	return content
 }
 
 func (d *Document) prepareCandidates() {
@@ -494,7 +499,7 @@ func (d *Document) cleanConditionally(s *goquery.Selection, selector string) {
 			} else if counts["li"] > counts["p"] && !s.Is("ul,ol") {
 				reason = "more <li>s than <p>s"
 				remove = true
-			} else if counts["input"] > int(counts["p"]/3.0) {
+			} else if counts["input"] > counts["p"]/3.0 {
 				reason = "less than 3x <p>s than <input>s"
 				remove = true
 			} else if contentLength < d.MinTextLength && (counts["img"] == 0 || counts["img"] > 2) {

--- a/readability_test.go
+++ b/readability_test.go
@@ -20,9 +20,20 @@ func TestGeneralFunctionality(t *testing.T) {
 
 	doc.MinTextLength = 0
 	doc.RetryLength = 1
-	content := doc.Content()
-	if !strings.Contains(content, "Some content") {
-		t.Errorf("Expected content %q to match %q", content, "Some content")
+	content, source := doc.ContentWithHTML()
+
+	const expectedContent = "Some content"
+	if !strings.Contains(content, expectedContent) {
+		t.Errorf("Expected content %q to match %q", content, expectedContent)
+	}
+
+	const expectedHTML = "<div><div><p>Some content</p></div></div>"
+	if source != expectedHTML {
+		t.Errorf("Expected source %q to match %q", source, expectedHTML)
+	}
+
+	if doc.Content() != content {
+		t.Errorf("Expected doc.Content %q to match %q", content, doc.Content())
 	}
 }
 


### PR DESCRIPTION
In one of my projects, I used this one, and I had to fork it to have the ability to manipulate not only the resulting content but also its HTML representation. This PR proposes these changes to the upstream version of the library so I could switch back to it from the fork, and everyone could benefit from it.